### PR TITLE
Bring env OSPROFILER_CONNECTION_STRING into effect

### DIFF
--- a/osprofiler/cmd/commands.py
+++ b/osprofiler/cmd/commands.py
@@ -36,7 +36,6 @@ class TraceCommands(BaseCommand):
     @cliutils.arg("trace", help="File with trace or trace id")
     @cliutils.arg("--connection-string", dest="conn_str",
                   default=(cliutils.env("OSPROFILER_CONNECTION_STRING")),
-                  required=True,
                   help="Storage driver's connection string. Defaults to "
                        "env[OSPROFILER_CONNECTION_STRING] if set")
     @cliutils.arg("--transport-url", dest="transport_url",
@@ -58,6 +57,12 @@ class TraceCommands(BaseCommand):
     @cliutils.arg("--out", dest="file_name", help="save output in file")
     def show(self, args):
         """Display trace results in HTML, JSON or DOT format."""
+
+        if not args.conn_str:
+            raise exc.CommandError(
+                "You must provide connection string via"
+                " either --connection-string or "
+                "via env[OSPROFILER_CONNECTION_STRING]")
 
         trace = None
 
@@ -156,7 +161,6 @@ class TraceCommands(BaseCommand):
 
     @cliutils.arg("--connection-string", dest="conn_str",
                   default=cliutils.env("OSPROFILER_CONNECTION_STRING"),
-                  required=True,
                   help="Storage driver's connection string. Defaults to "
                        "env[OSPROFILER_CONNECTION_STRING] if set")
     @cliutils.arg("--error-trace", dest="error_trace",
@@ -164,6 +168,11 @@ class TraceCommands(BaseCommand):
                   help="List all traces that contain error.")
     def list(self, args):
         """List all traces"""
+        if not args.conn_str:
+            raise exc.CommandError(
+                "You must provide connection string via"
+                " either --connection-string or "
+                "via env[OSPROFILER_CONNECTION_STRING]")
         try:
             engine = base.get_driver(args.conn_str, **args.__dict__)
         except Exception as e:


### PR DESCRIPTION
The --connection-string is marked required, and parse_args()
assumes the flag invalid if it's not supplied as command line
argument, even if env OSPROFILER_CONNECTION_STRING is setted.

We should not rely on the required=True of argparse module,
but check the required args on our own to take env arguments
into consideration.

Change-Id: I50f5f369ec41ddc82f9b66f5910b7805940fb387
(cherry picked from commit ede0ec402eee45e107c1fde429c3332b3e49f60e)